### PR TITLE
proton-cachyos/feat: add renameInternalName option

### DIFF
--- a/pkgs/proton-cachyos/default.nix
+++ b/pkgs/proton-cachyos/default.nix
@@ -2,6 +2,7 @@
   pkgs,
   source,
   variant,
+  renameInternalName ? true,
 }:
 
 let
@@ -33,6 +34,10 @@ pkgs.stdenv.mkDerivation {
     # Modify the display name
     sed -i -r "s|\"display_name\".*|\"display_name\" \"${steamName}\"|" \
       $steamcompattool/compatibilitytool.vdf
+
+    ${pkgs.lib.optionalString renameInternalName ''
+      sed -i -r 's|"proton-cachyos-[^"]*"(\s*// Internal name)|"${steamName}"\1|' $steamcompattool/compatibilitytool.vdf
+    ''}
 
     # Create a real folder so that Steam doesn't require reselecting compatibility tool on update
     mkdir -p $out/share/


### PR DESCRIPTION
Main motivation is to keep names consistent (like [Proton-GE in nixpkgs](https://github.com/NixOS/nixpkgs/blob/c0b0e0fddf73fd517c3471e546c0df87a42d53f4/pkgs/by-name/pr/proton-ge-bin/package.nix#L45), this also changes the internal name). This allows to use `proton-cachyos` packages with https://github.com/different-name/steam-config-nix as the naming scheme is now consistent. Did not build & test locally, but should work fine.

Before:
```
"compatibilitytools"
{
  "compat_tools"
  {
    "proton-cachyos-10.0-20251222-slr-x86_64_v4" // Internal name of this tool
    {
      // Can register this tool with Steam in two ways:
      //
      // - The tool can be placed as a subdirectory in compatibilitytools.d, in which case this
      //   should be '.'
      //
      // - This manifest can be placed directly in compatibilitytools.d, in which case this should
      //   be the relative or absolute path to the tool's dist directory.
      "install_path" "."

      // For this template, we're going to substitute the display_name key in here, e.g.:
      "display_name" "Proton CachyOS x86_64_v4"

      "from_oslist"  "windows"
      "to_oslist"    "linux"
    }
  }
}

```

After:
```
"compatibilitytools"
{
  "compat_tools"
  {
    "Proton CachyOS x86_64_v4" // Internal name of this tool
    {
      // Can register this tool with Steam in two ways:
      //
      // - The tool can be placed as a subdirectory in compatibilitytools.d, in which case this
      //   should be '.'
      //
      // - This manifest can be placed directly in compatibilitytools.d, in which case this should
      //   be the relative or absolute path to the tool's dist directory.
      "install_path" "."

      // For this template, we're going to substitute the display_name key in here, e.g.:
      "display_name" "Proton CachyOS x86_64_v4"

      "from_oslist"  "windows"
      "to_oslist"    "linux"
    }
  }
}

```
