### PR TITLE
build hytale on self-hosted to cache and avoid broken CDN targets

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -43,7 +43,7 @@
     {
       "name": "hytale",
       "packages": "hytale-launcher",
-      "runner": "ubuntu-latest"
+      "runner": ["self-hosted", "light-tasks"]
     }
   ]
 }


### PR DESCRIPTION
Hytale's CDN only serves the current version of the launcher. Cache builds so that someone downloading Hytale before the next Wednesday bump can instead download it from the cache and avoid a broken URL preventing installation otherwise.