### PR TITLE
mesa-git: preserve `.override` on wrapped buildFHSEnv

### DIFF
--- a/modules/mesa-git.nix
+++ b/modules/mesa-git.nix
@@ -334,17 +334,34 @@ in
                     );
                   }
                 );
+            # Returns a callable attrset (functor) that preserves `.override`.
+            # `pkgs.buildFHSEnv` is `makeOverridable buildFHSEnv'`, and callers
+            # like nixos/modules/programs/steam.nix do
+            #   buildFHSEnv = pkgs.buildFHSEnv.override { ... };
+            # to swap in setuid bubblewrap when gamescopeSession + capSysNice
+            # are both enabled. A plain function loses `.override`, so that
+            # callsite fails with "expected a set but found a function".
             wrapFhsEnv =
-              orig: args:
-              orig (
-                args
-                // lib.optionalAttrs (args ? targetPkgs) {
-                  targetPkgs = p: args.targetPkgs (withLibdrmGit p);
-                }
-                // lib.optionalAttrs (args ? multiPkgs) {
-                  multiPkgs = p: args.multiPkgs (withLibdrmGit p);
-                }
-              );
+              orig:
+              let
+                wrap =
+                  args:
+                  orig (
+                    args
+                    // lib.optionalAttrs (args ? targetPkgs) {
+                      targetPkgs = p: args.targetPkgs (withLibdrmGit p);
+                    }
+                    // lib.optionalAttrs (args ? multiPkgs) {
+                      multiPkgs = p: args.multiPkgs (withLibdrmGit p);
+                    }
+                  );
+              in
+              {
+                __functor = _: wrap;
+              }
+              // lib.optionalAttrs (orig ? override) {
+                override = newArgs: wrapFhsEnv (orig.override newArgs);
+              };
           in
           {
             # buildFHSEnv is an alias; some packages call it directly, wrap both.


### PR DESCRIPTION
## Summary

The current \`wrapFhsEnv\` in \`modules/mesa-git.nix\` turns \`pkgs.buildFHSEnv\` into a plain function:

\`\`\`nix
wrapFhsEnv = orig: args: orig (args // ...);
\`\`\`

This drops \`.override\`. \`nixos/modules/programs/steam.nix\` (line 85, current nixos-unstable) calls

\`\`\`nix
buildFHSEnv = pkgs.buildFHSEnv.override {
  # use the setuid wrapped bubblewrap
  ...
};
\`\`\`

when both \`programs.steam.gamescopeSession.enable\` and \`programs.gamescope.capSysNice\` are true (the standard "Steam Big Picture session + setuid bubblewrap" combo). Any host that enables \`drivers.mesa-git.enable\` alongside that pair fails to evaluate with:

\`\`\`
error: expected a set but found a function: «lambda wrapFhsEnv @ .../modules/mesa-git.nix:338:21»
\`\`\`

## Fix

Wrap as a callable attrset (\`__functor\` + \`override\`) instead of a plain function:

\`\`\`nix
wrapFhsEnv = orig:
  let wrap = args: orig (args // {libdrm-git rewrite});
  in {
    __functor = _: wrap;
  } // lib.optionalAttrs (orig ? override) {
    override = newArgs: wrapFhsEnv (orig.override newArgs);
  };
\`\`\`

\`__functor\` makes the value callable (so existing \`pkgs.buildFHSEnv {...}\` callsites keep working). \`override\` recurses through \`wrapFhsEnv (orig.override newArgs)\` so chained overrides keep the \`libdrm-git\` rewrite applied.

The \`lib.optionalAttrs (orig ? override)\` guard preserves behavior if \`buildFHSEnv\` is ever passed something that doesn't carry \`makeOverridable\`.

## Test plan

- [x] \`nix eval .#nixosConfigurations.<host>.config.system.build.toplevel.drvPath\` succeeds on a host with \`drivers.mesa-git.enable = true\`, \`programs.steam.gamescopeSession.enable = true\`, \`programs.gamescope.capSysNice = true\`. Reproduces the failure on master, evaluates cleanly on this branch.
- [ ] System rebuild + Steam launch (will report back after deploying)