### PR TITLE
Tidy up Module Config & Some conditional fixes / improvements

### DIFF
--- a/modules/mesa-git.nix
+++ b/modules/mesa-git.nix
@@ -284,101 +284,103 @@ in
     };
   };
 
-  config = lib.mkMerge [
-    (lib.mkIf cfg.enableCache {
-      nix.settings = {
-        substituters = [ "https://nix-cache.tokidoki.dev/tokidoki" ];
-        trusted-public-keys = [ "tokidoki:MD4VWt3kK8Fmz3jkiGoNRJIW31/QAm7l1Dcgz2Xa4hk=" ];
-      };
-    })
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        assertions = [
+          {
+            assertion = pkgs ? mesa-git;
+            message = ''
+              drivers.mesa-git requires the mesa-git overlay.
+              Add to your configuration:
+                nixpkgs.overlays = [ inputs.mesa-git.overlays.default ];
+            '';
+          }
+        ];
 
-    (lib.mkIf cfg.enable {
-      assertions = [
-        {
-          assertion = pkgs ? mesa-git;
-          message = ''
-            drivers.mesa-git requires the mesa-git overlay.
-            Add to your configuration:
-              nixpkgs.overlays = [ inputs.mesa-git.overlays.default ];
-          '';
-        }
-      ];
-
-      hardware.graphics = {
-        enable = true;
-        package = pkgs.mesa-git;
-        enable32Bit = shouldEnable32Bit;
-      }
-      // lib.optionalAttrs shouldEnable32Bit {
-        package32 = pkgs.mesa32-git;
-      };
-
-      # mesa-git's libgallium needs symbols from libdrm-git and apps that use LD_LIBRARY_PATH
-      # crash when libgallium is opened because they prepend stable libdrm and load that first.
-      # Preload the libdrm-git libraries to satisfy apps that do this. Chrome under Wayland needs this.
-      environment.sessionVariables.LD_PRELOAD = map (so: "${pkgs.libdrm-git}/lib/${so}") [
-        "libdrm.so.2"
-        "libdrm_amdgpu.so.1"
-        "libdrm_radeon.so.1"
-        "libdrm_intel.so.1"
-        "libdrm_nouveau.so.2"
-      ];
-
-      # mesa-git correctly uses libdrm-git and now fails inside any FHS env that
-      # ships stable libdrm (e.g. Steam!). Overlay lives in a shared file so a
-      # cache builder can apply the identical swap — see overlays/libdrm-git-fhsenv.nix.
-      nixpkgs.overlays = [ (import ../overlays/libdrm-git-fhsenv.nix) ];
-    })
-
-    (lib.mkIf (cfg.enable && cfg.withStableFallback) {
-      specialisation.stable-mesa.configuration = {
-        system.nixos.tags = [ "stable-mesa" ];
-        drivers.mesa-git.enable = lib.mkForce false;
         hardware.graphics = {
-          package = lib.mkForce pkgs.mesa;
-          package32 = lib.mkIf shouldEnable32Bit (lib.mkForce pkgs.pkgsi686Linux.mesa);
+          enable = true;
+          package = pkgs.mesa-git;
+          enable32Bit = shouldEnable32Bit;
+        }
+        // lib.optionalAttrs shouldEnable32Bit {
+          package32 = pkgs.mesa32-git;
         };
-      };
-    })
 
-    # NEW: Use systemd services instead of activation scripts
-    (lib.mkIf (cfg.enable && cfg.cacheCleanup.enable) {
-      systemd.services.mesa-cache-cleaner = {
-        description = "removing Mesa shader caches";
-        wantedBy = [ "multi-user.target" ];
-        after = [ "local-fs.target" ];
-        serviceConfig = {
-          Type = "oneshot";
-          ExecStart = "${mesaCacheCleanerScript} ${pkgs.mesa-git.version}";
-          RemainAfterExit = true;
-        };
-      };
-    })
+        # mesa-git's libgallium needs symbols from libdrm-git and apps that use LD_LIBRARY_PATH
+        # crash when libgallium is opened because they prepend stable libdrm and load that first.
+        # Preload the libdrm-git libraries to satisfy apps that do this. Chrome under Wayland needs this.
+        environment.sessionVariables.LD_PRELOAD = map (so: "${pkgs.libdrm-git}/lib/${so}") [
+          "libdrm.so.2"
+          "libdrm_amdgpu.so.1"
+          "libdrm_radeon.so.1"
+          "libdrm_intel.so.1"
+          "libdrm_nouveau.so.2"
+        ];
 
-    (lib.mkIf (cfg.enable && cfg.cacheCleanup.enable && cfg.cacheCleanup.protonPackage != null) {
-      systemd.services.proton-cache-cleaner = {
-        description = "removing Proton shader caches";
-        wantedBy = [ "multi-user.target" ];
-        after = [ "local-fs.target" ];
-        serviceConfig = {
-          Type = "oneshot";
-          ExecStart = "${protonCacheCleanerScript} ${cfg.cacheCleanup.protonPackage.version}";
-          RemainAfterExit = true;
-        };
-      };
-    })
+        # mesa-git correctly uses libdrm-git and now fails inside any FHS env that
+        # ships stable libdrm (e.g. Steam!). Overlay lives in a shared file so a
+        # cache builder can apply the identical swap — see overlays/libdrm-git-fhsenv.nix.
+        nixpkgs.overlays = [ (import ../overlays/libdrm-git-fhsenv.nix) ];
+      }
 
-    (lib.mkIf (cfg.enable && cfg.steamOrphanCleanup.enable) {
-      systemd.services.steam-orphan-cleaner = {
-        description = "removing orphaned Steam game folders and prefixes";
-        wantedBy = [ "multi-user.target" ];
-        after = [ "local-fs.target" ];
-        serviceConfig = {
-          Type = "oneshot";
-          ExecStart = "${steamOrphanCleanerScript}";
-          RemainAfterExit = true;
+      (lib.mkIf cfg.enableCache {
+        nix.settings = {
+          substituters = [ "https://nix-cache.tokidoki.dev/tokidoki" ];
+          trusted-public-keys = [ "tokidoki:MD4VWt3kK8Fmz3jkiGoNRJIW31/QAm7l1Dcgz2Xa4hk=" ];
         };
-      };
-    })
-  ];
+      })
+
+      (lib.mkIf cfg.withStableFallback {
+        specialisation.stable-mesa.configuration = {
+          system.nixos.tags = [ "stable-mesa" ];
+          drivers.mesa-git.enable = lib.mkForce false;
+          hardware.graphics = {
+            package = lib.mkForce pkgs.mesa;
+            package32 = lib.mkIf shouldEnable32Bit (lib.mkForce pkgs.pkgsi686Linux.mesa);
+          };
+        };
+      })
+
+      # NEW: Use systemd services instead of activation scripts
+      (lib.mkIf cfg.cacheCleanup.enable {
+        systemd.services.mesa-cache-cleaner = {
+          description = "removing Mesa shader caches";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "local-fs.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = "${mesaCacheCleanerScript} ${pkgs.mesa-git.version}";
+            RemainAfterExit = true;
+          };
+        };
+      })
+
+      (lib.mkIf (cfg.cacheCleanup.enable && cfg.cacheCleanup.protonPackage != null) {
+        systemd.services.proton-cache-cleaner = {
+          description = "removing Proton shader caches";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "local-fs.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = "${protonCacheCleanerScript} ${cfg.cacheCleanup.protonPackage.version}";
+            RemainAfterExit = true;
+          };
+        };
+      })
+
+      (lib.mkIf cfg.steamOrphanCleanup.enable {
+        systemd.services.steam-orphan-cleaner = {
+          description = "removing orphaned Steam game folders and prefixes";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "local-fs.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = "${steamOrphanCleanerScript}";
+            RemainAfterExit = true;
+          };
+        };
+      })
+    ]
+  );
 }


### PR DESCRIPTION
The entire config declaration should hang on `cfg.enable` being true, as otherwise the module makes changes to a users config without explicit approval (as module imports are config agnostic)


In addition, wrapping the config declaration in `cfg.enable` allows simplification of some of the module conditions.
