### PR TITLE
fix: correct proton-cachyos 11.0-20260602 source hashes

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -213,7 +213,7 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-KeYloyihLtG7BzNh4280H+yKYu8KND07vc3vZfwpZAY=",
+            "sha256": "sha256-qC20cEi08yTC1RMu8mCXbrIf+yl1QBUpFSKzRKzmZTg=",
             "type": "url",
             "url": "https://github.com/CachyOS/proton-cachyos/releases/download/cachyos-11.0-20260602-slr/proton-cachyos-11.0-20260602-slr-x86_64.tar.xz"
         },
@@ -228,7 +228,7 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-g74Xzfp1LKNVyTYssAsTZJl/MN/GScFvLwgMKsBxJYs=",
+            "sha256": "sha256-HZmTHTziUU2nfmSTinG8qJntTweI5Xtk8SZ3BnHgpmI=",
             "type": "url",
             "url": "https://github.com/CachyOS/proton-cachyos/releases/download/cachyos-11.0-20260602-slr/proton-cachyos-11.0-20260602-slr-x86_64_v3.tar.xz"
         },

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -136,7 +136,7 @@
     version = "cachyos-11.0-20260602-slr";
     src = fetchurl {
       url = "https://github.com/CachyOS/proton-cachyos/releases/download/cachyos-11.0-20260602-slr/proton-cachyos-11.0-20260602-slr-x86_64.tar.xz";
-      sha256 = "sha256-KeYloyihLtG7BzNh4280H+yKYu8KND07vc3vZfwpZAY=";
+      sha256 = "sha256-qC20cEi08yTC1RMu8mCXbrIf+yl1QBUpFSKzRKzmZTg=";
     };
   };
   proton-cachyos-x86_64-v3 = {
@@ -144,7 +144,7 @@
     version = "cachyos-11.0-20260602-slr";
     src = fetchurl {
       url = "https://github.com/CachyOS/proton-cachyos/releases/download/cachyos-11.0-20260602-slr/proton-cachyos-11.0-20260602-slr-x86_64_v3.tar.xz";
-      sha256 = "sha256-g74Xzfp1LKNVyTYssAsTZJl/MN/GScFvLwgMKsBxJYs=";
+      sha256 = "sha256-HZmTHTziUU2nfmSTinG8qJntTweI5Xtk8SZ3BnHgpmI=";
     };
   };
   pseudoregalia-rando = {


### PR DESCRIPTION
The 20260602 sources bump recorded the wrong sha256 for both proton-cachyos release tarballs, so any build that fetches them fails with a fixed-output hash mismatch. I refetched both published assets and corrected `_sources/generated.{nix,json}`:

```
x86_64
  was: sha256-KeYloyihLtG7BzNh4280H+yKYu8KND07vc3vZfwpZAY=
  now: sha256-qC20cEi08yTC1RMu8mCXbrIf+yl1QBUpFSKzRKzmZTg=

x86_64_v3
  was: sha256-g74Xzfp1LKNVyTYssAsTZJl/MN/GScFvLwgMKsBxJYs=
  now: sha256-HZmTHTziUU2nfmSTinG8qJntTweI5Xtk8SZ3BnHgpmI=
```

Reproduce with `nix store prefetch-file` on either release asset, e.g.:

```
nix store prefetch-file https://github.com/CachyOS/proton-cachyos/releases/download/cachyos-11.0-20260602-slr/proton-cachyos-11.0-20260602-slr-x86_64_v3.tar.xz
```

`proton-cachyos-x86_64-v3` builds cleanly with the corrected hashes.
